### PR TITLE
Add platform specification for ARM64 compatibility in docker-compose.yml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   bootnode:
     image: ghcr.io/arch-network/bootnode:latest
+    platform: linux/amd64
     ports:
       - 19001:19001
     environment:
@@ -17,6 +18,7 @@ services:
 
   validator-1:
     build: ./docker/validator
+    platform: linux/amd64
     ports:
       - 19002:19002
       - 9002:9002
@@ -48,6 +50,7 @@ services:
 
   validator-2:
     build: ./docker/validator
+    platform: linux/amd64
     ports:
       - 19003:19003
       - 9003:9003


### PR DESCRIPTION
This Pull Request addresses compatibility issues for ARM64 systems by adding platform specifications to the docker-compose.yml file. The following changes have been made:

Added platform: linux/amd64 to the bootnode, validator-1, and validator-2 services. This change enables these services to run on ARM64 systems (such as M1/M2 Macs) by explicitly specifying the amd64 platform, which will use emulation when necessary. The modification ensures that the correct image architecture is pulled and used, resolving "no matching manifest" errors that were previously encountered on ARM64 systems.

These changes improve the project's compatibility across different system architectures, making it easier for developers using ARM64-based machines to run and test the Arch Network nodes locally. Testing:

Verified that docker compose up successfully pulls and runs all services on an ARM64 system. Ensured that the bootnode and validator nodes start and communicate correctly.

Note: While this solution enables the services to run on ARM64 systems, it may impact performance due to architecture emulation. Future improvements could include building native ARM64 images for optimal performance across all systems.